### PR TITLE
[#19] feature: 회원정보 수정 및 생성로직 수정

### DIFF
--- a/src/main/java/com/project/poorlex/api/controller/MemberController.java
+++ b/src/main/java/com/project/poorlex/api/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.project.poorlex.api.controller;
 
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,6 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.project.poorlex.api.service.MemberService;
 import com.project.poorlex.dto.member.MemberCreateRequest;
 import com.project.poorlex.dto.member.MemberLoginResponse;
+import com.project.poorlex.dto.member.MemberUpdateRequest;
+import com.project.poorlex.dto.member.MemberUpdateResponse;
 import com.project.poorlex.exception.ApiResponse;
 
 import jakarta.validation.Valid;
@@ -26,4 +29,9 @@ public class MemberController {
 		return ApiResponse.ok(memberService.createOrLogin(request));
 	}
 
+	@PutMapping
+	public ApiResponse<MemberUpdateResponse> update(
+		@RequestBody @Valid MemberUpdateRequest request) {
+		return ApiResponse.ok(memberService.updateMember(request));
+	}
 }

--- a/src/main/java/com/project/poorlex/api/service/MemberService.java
+++ b/src/main/java/com/project/poorlex/api/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.project.poorlex.api.service;
 
+import static com.project.poorlex.exception.member.MemberErrorCode.*;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,11 +9,11 @@ import com.project.poorlex.domain.member.Member;
 import com.project.poorlex.domain.member.MemberRepository;
 import com.project.poorlex.dto.member.MemberCreateRequest;
 import com.project.poorlex.dto.member.MemberLoginResponse;
+import com.project.poorlex.dto.member.MemberUpdateRequest;
+import com.project.poorlex.dto.member.MemberUpdateResponse;
 import com.project.poorlex.exception.member.MemberCustomException;
-import com.project.poorlex.exception.member.MemberErrorCode;
 import com.project.poorlex.jwt.JwtTokenProvider;
 import com.project.poorlex.jwt.Token;
-import com.project.poorlex.util.AuthUtil;
 import com.project.poorlex.util.RedisUtil;
 
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+	private final AuthService authService;
 	private final JwtTokenProvider jwtTokenProvider;
 	private final RedisUtil redisUtil;
 
@@ -30,18 +33,24 @@ public class MemberService {
 		Member member;
 		if (memberRepository.existsByOauthId(request.getOauthId())) {
 			member = memberRepository.findByOauthId(request.getOauthId())
-				.orElseThrow(() -> new MemberCustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+				.orElseThrow(() -> new MemberCustomException(MEMBER_NOT_FOUND));
 		} else {
-			member = memberRepository.save(Member.create(request));
+			member = memberRepository.save(request.toEntity());
 		}
 		Token token = jwtTokenProvider.createAccessToken(member.getId().toString());
 		redisUtil.setData(String.valueOf(member.getId()), token.getRefreshToken());
 		return MemberLoginResponse.of(token);
 	}
 
-	public Member findMemberFromToken() {
-		return memberRepository.findById(AuthUtil.getCurrentUserId())
-			.orElseThrow(() -> new MemberCustomException(MemberErrorCode.INVALID_TOKEN));
+	@Transactional
+	public MemberUpdateResponse updateMember(MemberUpdateRequest request) {
+		Member member = authService.findMemberFromToken();
+		member.update(request);
+		return MemberUpdateResponse.of(member);
 	}
 
+	public Member findMemberById(Long id) {
+		return memberRepository.findById(id)
+			.orElseThrow(() -> new MemberCustomException(MEMBER_NOT_FOUND));
+	}
 }

--- a/src/main/java/com/project/poorlex/domain/member/Member.java
+++ b/src/main/java/com/project/poorlex/domain/member/Member.java
@@ -1,9 +1,7 @@
 package com.project.poorlex.domain.member;
 
-import static com.project.poorlex.domain.member.MemberRole.*;
-
 import com.project.poorlex.domain.BaseEntity;
-import com.project.poorlex.dto.member.MemberCreateRequest;
+import com.project.poorlex.dto.member.MemberUpdateRequest;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -48,12 +46,8 @@ public class Member extends BaseEntity {
 		this.memberRole = memberRole;
 	}
 
-	public static Member create(MemberCreateRequest request) {
-		return Member.builder()
-			.oauthId(request.getOauthId())
-			.email(request.getEmail())
-			.name(request.getName())
-			.memberRole(USER)
-			.build();
+	public void update(MemberUpdateRequest request) {
+		this.name = request.getName();
+		this.description = request.getDescription();
 	}
 }

--- a/src/main/java/com/project/poorlex/dto/member/MemberCreateRequest.java
+++ b/src/main/java/com/project/poorlex/dto/member/MemberCreateRequest.java
@@ -1,5 +1,9 @@
 package com.project.poorlex.dto.member;
 
+import static com.project.poorlex.domain.member.MemberRole.*;
+
+import com.project.poorlex.domain.member.Member;
+
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,12 +16,21 @@ import lombok.NoArgsConstructor;
 @Getter
 public class MemberCreateRequest {
 
-	@NotBlank
+	@NotBlank(message = "고유번호는 필수입니다.")
 	private String oauthId;
-	@NotBlank
+	@NotBlank(message = "이메일은 필수입니다.")
 	private String email;
-	@NotBlank
+	@NotBlank(message = "닉네임은 필수입니다.")
 	private String name;
+
+	public Member toEntity() {
+		return Member.builder()
+			.oauthId(oauthId)
+			.email(email)
+			.name(name)
+			.memberRole(USER)
+			.build();
+	}
 }
 
 

--- a/src/main/java/com/project/poorlex/dto/member/MemberUpdateRequest.java
+++ b/src/main/java/com/project/poorlex/dto/member/MemberUpdateRequest.java
@@ -1,0 +1,23 @@
+package com.project.poorlex.dto.member;
+
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MemberUpdateRequest {
+
+	@Size(min = 2, max = 15, message = "닉네임은 2자 이상 15자 이하여야 합니다.")
+	private String name;
+
+	@Size(max = 100, message = "상태 메세지는 100자 내로 입력해야 합니다.")
+	private String description;
+
+	@Builder
+	private MemberUpdateRequest(String name, String description) {
+		this.name = name;
+		this.description = description;
+	}
+}

--- a/src/main/java/com/project/poorlex/dto/member/MemberUpdateResponse.java
+++ b/src/main/java/com/project/poorlex/dto/member/MemberUpdateResponse.java
@@ -1,0 +1,27 @@
+package com.project.poorlex.dto.member;
+
+import com.project.poorlex.domain.member.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberUpdateResponse {
+
+	private String name;
+
+	private String description;
+
+	@Builder
+	private MemberUpdateResponse(String name, String description) {
+		this.name = name;
+		this.description = description;
+	}
+
+	public static MemberUpdateResponse of(Member member) {
+		return MemberUpdateResponse.builder()
+			.name(member.getName())
+			.description(member.getDescription())
+			.build();
+	}
+}


### PR DESCRIPTION
## Issue

- #19 

## Description
- 회원정보 수정과 생성로직의 일부 수정 부분이 함께 있습니다.
- `MemberService` 내에 `findMemberFromToken()`은 `AuthService`로 옮겨져 삭제하였습니다.
- Entity에 Create 로직을 담는 것은 위험하다 생각하여 `MemberCreateRequest.toEntity`로 옮겼습니다.
- Postman 및 통합테스트 모두 검증 하였습니다!
  -  추후에 PR 올리겠습니다!

## ETC
- 궁금하신점 댓글 남겨주세요.
