### PR TITLE
[#28] feature: 지출 입력 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
+    // AWS S3
+    implementation 'software.amazon.awssdk:s3:2.20.136'
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/project/poorlex/api/controller/BattleController.java
+++ b/src/main/java/com/project/poorlex/api/controller/BattleController.java
@@ -16,25 +16,25 @@ public class BattleController {
 
     @PostMapping
     public ApiResponse<BattleCreateResponse> createBattle(
-            @RequestBody BattleCreateRequest request) {
+        @RequestBody BattleCreateRequest request) {
         return ApiResponse.ok(battleService.createBattleAndBattleUser(request));
     }
 
     @GetMapping
     public ApiResponse<BattleSearchResponse> searchBattle(
-            @RequestParam BattleFilter filter) {
+        @RequestParam BattleFilter filter) {
         return ApiResponse.ok(battleService.searchBattle(filter));
     }
 
     @GetMapping("/join")
     public ApiResponse<BattleJoinResponse> joinBattle(
-            @RequestParam Long battleId) {
+        @RequestParam Long battleId) {
         return ApiResponse.ok(battleService.joinBattle(battleId));
     }
 
     @GetMapping("/detail")
     public ApiResponse<BattleDetailResponse> searchDetailBattle(
-            @RequestParam Long battleId) {
+        @RequestParam Long battleId) {
         return ApiResponse.ok(battleService.searchBattleDetail(battleId));
     }
 }

--- a/src/main/java/com/project/poorlex/api/controller/BattleController.java
+++ b/src/main/java/com/project/poorlex/api/controller/BattleController.java
@@ -16,25 +16,25 @@ public class BattleController {
 
     @PostMapping
     public ApiResponse<BattleCreateResponse> createBattle(
-        @RequestBody BattleCreateRequest request) {
+            @RequestBody BattleCreateRequest request) {
         return ApiResponse.ok(battleService.createBattleAndBattleUser(request));
     }
 
     @GetMapping
     public ApiResponse<BattleSearchResponse> searchBattle(
-        @RequestParam BattleFilter filter) {
+            @RequestParam BattleFilter filter) {
         return ApiResponse.ok(battleService.searchBattle(filter));
     }
 
     @GetMapping("/join")
     public ApiResponse<BattleJoinResponse> joinBattle(
-            @RequestParam Long battleId){
+            @RequestParam Long battleId) {
         return ApiResponse.ok(battleService.joinBattle(battleId));
     }
 
     @GetMapping("/detail")
     public ApiResponse<BattleDetailResponse> searchDetailBattle(
-            @RequestParam Long battleId){
+            @RequestParam Long battleId) {
         return ApiResponse.ok(battleService.searchBattleDetail(battleId));
     }
 }

--- a/src/main/java/com/project/poorlex/api/controller/PaymentController.java
+++ b/src/main/java/com/project/poorlex/api/controller/PaymentController.java
@@ -24,7 +24,7 @@ public class PaymentController {
     @PostMapping
     public ApiResponse<PaymentCreateResponse> createPayment(
             @RequestPart("request")PaymentCreateRequest request,
-            @RequestPart("images") List<MultipartFile> images){
+            @RequestPart(value = "images", required = false) List<MultipartFile> images){
         return ApiResponse.ok(paymentService.createPayment(request, images));
     }
 

--- a/src/main/java/com/project/poorlex/api/controller/PaymentController.java
+++ b/src/main/java/com/project/poorlex/api/controller/PaymentController.java
@@ -1,0 +1,31 @@
+package com.project.poorlex.api.controller;
+
+import com.project.poorlex.api.service.PaymentService;
+import com.project.poorlex.dto.payment.PaymentCreateRequest;
+import com.project.poorlex.dto.payment.PaymentCreateResponse;
+import com.project.poorlex.exception.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/payment")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping
+    public ApiResponse<PaymentCreateResponse> createPayment(
+            @RequestPart("request")PaymentCreateRequest request,
+            @RequestPart("images") List<MultipartFile> images){
+        return ApiResponse.ok(paymentService.createPayment(request, images));
+    }
+
+}

--- a/src/main/java/com/project/poorlex/api/service/PaymentService.java
+++ b/src/main/java/com/project/poorlex/api/service/PaymentService.java
@@ -47,13 +47,15 @@ public class PaymentService {
 
         Payment savedPayment = paymentRepository.save(payment);
 
-        images.forEach(file -> {
-            String key = "payments/" + file.getOriginalFilename(); // S3 내의 저장 경로
-            uploadToS3(file, "poorlex", key);
+        if(images != null && !images.isEmpty()){
+            images.forEach(file -> {
+                String key = "payments/" + file.getOriginalFilename(); // S3 내의 저장 경로
+                uploadToS3(file, "poorlex", key);
 
-            String imageUrl = generateS3Url("poorlex", key);
-            savePaymentImages(savedPayment, imageUrl);
-        });
+                String imageUrl = generateS3Url("poorlex", key);
+                savePaymentImages(savedPayment, imageUrl);
+            });
+        }
 
         PaymentCreateResponse response = new PaymentCreateResponse();
 

--- a/src/main/java/com/project/poorlex/api/service/PaymentService.java
+++ b/src/main/java/com/project/poorlex/api/service/PaymentService.java
@@ -1,0 +1,90 @@
+package com.project.poorlex.api.service;
+
+import com.project.poorlex.domain.member.Member;
+import com.project.poorlex.domain.payment.Payment;
+import com.project.poorlex.domain.payment.PaymentRepository;
+import com.project.poorlex.domain.paymentimage.PaymentImage;
+import com.project.poorlex.domain.paymentimage.PaymentImageRepository;
+import com.project.poorlex.dto.payment.PaymentCreateRequest;
+import com.project.poorlex.dto.payment.PaymentCreateResponse;
+import com.project.poorlex.exception.payment.PaymentCustomException;
+import com.project.poorlex.exception.payment.PaymentErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final AuthService authService;
+
+    private final PaymentRepository paymentRepository;
+
+    private final PaymentImageRepository paymentImageRepository;
+
+    private final S3Client s3Client = S3Client.builder()
+            .region(Region.AP_NORTHEAST_2)
+            .build();
+
+    @Transactional
+    public PaymentCreateResponse createPayment(PaymentCreateRequest request, List<MultipartFile> images) {
+
+        Member member = authService.findMemberFromToken();
+
+        Payment payment = Payment.builder()
+                .member(member)
+                .memo(request.getMemo())
+                .amount(request.getAmount())
+                .build();
+
+        Payment savedPayment = paymentRepository.save(payment);
+
+        images.forEach(file -> {
+            String key = "payments/" + file.getOriginalFilename(); // S3 내의 저장 경로
+            uploadToS3(file, "poorlex", key);
+
+            String imageUrl = generateS3Url("poorlex", key);
+            savePaymentImages(savedPayment, imageUrl);
+        });
+
+        PaymentCreateResponse response = new PaymentCreateResponse();
+
+        return response;
+    }
+
+    private void savePaymentImages(Payment payment, String imageUrl) {
+        PaymentImage paymentImage = PaymentImage.builder()
+                .payment(payment)
+                .url(imageUrl)
+                .build();
+
+        paymentImageRepository.save(paymentImage);
+    }
+
+    private String generateS3Url(String bucketName, String key) {
+        return "https://" + bucketName + ".s3." + Region.AP_NORTHEAST_2.id() + ".amazonaws.com/" + key;
+    }
+
+
+    private void uploadToS3(MultipartFile file, String bucketName, String key) {
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (Exception e) {
+            throw new PaymentCustomException(PaymentErrorCode.FAIL_UPLOAD_IMAGE);
+        }
+    }
+
+}

--- a/src/main/java/com/project/poorlex/api/service/S3Service.java
+++ b/src/main/java/com/project/poorlex/api/service/S3Service.java
@@ -1,0 +1,35 @@
+package com.project.poorlex.api.service;
+
+import com.project.poorlex.exception.payment.PaymentCustomException;
+import com.project.poorlex.exception.payment.PaymentErrorCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+public class S3Service {
+
+    private final Region region = Region.AP_NORTHEAST_2;
+
+    private final S3Client s3Client = S3Client.builder().region(region).build();
+
+    public void uploadToS3(MultipartFile file, String bucketName, String key) {
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (Exception e) {
+            throw new PaymentCustomException(PaymentErrorCode.FAIL_UPLOAD_IMAGE);
+        }
+    }
+
+    public String generateS3Url(String bucketName, String key) {
+        return "https://" + bucketName + ".s3." + region.id() + ".amazonaws.com/" + key;
+    }
+}

--- a/src/main/java/com/project/poorlex/domain/payment/Payment.java
+++ b/src/main/java/com/project/poorlex/domain/payment/Payment.java
@@ -4,6 +4,7 @@ import com.project.poorlex.domain.BaseEntity;
 import com.project.poorlex.domain.battleuser.BattleUser;
 import com.project.poorlex.domain.budget.Budget;
 
+import com.project.poorlex.domain.member.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -25,23 +26,16 @@ public class Payment extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	private BattleUser battleUser;
+	private Member member;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	private Budget budget;
-
-	private String content;
-
-	private String category;
+	private String memo;
 
 	private int amount;
 
 	@Builder
-	private Payment(BattleUser battleUser, Budget budget, String content, String category, int amount) {
-		this.battleUser = battleUser;
-		this.budget = budget;
-		this.content = content;
-		this.category = category;
+	private Payment(Member member, String memo, int amount) {
+		this.member = member;
+		this.memo = memo;
 		this.amount = amount;
 	}
 }

--- a/src/main/java/com/project/poorlex/domain/payment/PaymentRepository.java
+++ b/src/main/java/com/project/poorlex/domain/payment/PaymentRepository.java
@@ -3,4 +3,5 @@ package com.project.poorlex.domain.payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
 }

--- a/src/main/java/com/project/poorlex/domain/payment/PaymentRepository.java
+++ b/src/main/java/com/project/poorlex/domain/payment/PaymentRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
+    Payment findTopByOrderByIdDesc();
+
 }

--- a/src/main/java/com/project/poorlex/domain/paymentimage/PaymentImage.java
+++ b/src/main/java/com/project/poorlex/domain/paymentimage/PaymentImage.java
@@ -1,4 +1,4 @@
-package com.project.poorlex.domain.paymentphoto;
+package com.project.poorlex.domain.paymentimage;
 
 import com.project.poorlex.domain.BaseEntity;
 import com.project.poorlex.domain.payment.Payment;
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PaymentPhoto extends BaseEntity {
+public class PaymentImage extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,7 +29,7 @@ public class PaymentPhoto extends BaseEntity {
 	private String url;
 
 	@Builder
-	private PaymentPhoto(Payment payment, String url) {
+	private PaymentImage(Payment payment, String url) {
 		this.payment = payment;
 		this.url = url;
 	}

--- a/src/main/java/com/project/poorlex/domain/paymentimage/PaymentImageRepository.java
+++ b/src/main/java/com/project/poorlex/domain/paymentimage/PaymentImageRepository.java
@@ -1,0 +1,6 @@
+package com.project.poorlex.domain.paymentimage;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentImageRepository extends JpaRepository<PaymentImage, Long> {
+}

--- a/src/main/java/com/project/poorlex/domain/paymentphoto/PaymentPhotoRepository.java
+++ b/src/main/java/com/project/poorlex/domain/paymentphoto/PaymentPhotoRepository.java
@@ -1,6 +1,0 @@
-package com.project.poorlex.domain.paymentphoto;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PaymentPhotoRepository extends JpaRepository<PaymentPhoto, Long> {
-}

--- a/src/main/java/com/project/poorlex/dto/payment/PaymentCreateRequest.java
+++ b/src/main/java/com/project/poorlex/dto/payment/PaymentCreateRequest.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@Builder
 public class PaymentCreateRequest {
 
     private int amount;

--- a/src/main/java/com/project/poorlex/dto/payment/PaymentCreateRequest.java
+++ b/src/main/java/com/project/poorlex/dto/payment/PaymentCreateRequest.java
@@ -1,0 +1,21 @@
+package com.project.poorlex.dto.payment;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class PaymentCreateRequest {
+
+    private int amount;
+
+    private LocalDate paymentDate;
+
+    private String memo;
+
+    private List<MultipartFile> images;
+
+}

--- a/src/main/java/com/project/poorlex/dto/payment/PaymentCreateResponse.java
+++ b/src/main/java/com/project/poorlex/dto/payment/PaymentCreateResponse.java
@@ -1,0 +1,13 @@
+package com.project.poorlex.dto.payment;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentCreateResponse {
+
+    private Long id;
+
+}

--- a/src/main/java/com/project/poorlex/dto/payment/PaymentSearchResponse.java
+++ b/src/main/java/com/project/poorlex/dto/payment/PaymentSearchResponse.java
@@ -1,0 +1,29 @@
+package com.project.poorlex.dto.payment;
+
+import com.project.poorlex.domain.payment.Payment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PaymentSearchResponse {
+
+    private final List<Payment> paymentList;
+
+    private final Payment payment;
+
+    public static PaymentSearchResponse from(List<Payment> paymentList) {
+        return PaymentSearchResponse.builder()
+                .paymentList(paymentList)
+                .build();
+    }
+
+    public static PaymentSearchResponse from(Payment payment){
+        return PaymentSearchResponse.builder()
+                .payment(payment)
+                .build();
+    }
+
+}

--- a/src/main/java/com/project/poorlex/exception/payment/PaymentCustomException.java
+++ b/src/main/java/com/project/poorlex/exception/payment/PaymentCustomException.java
@@ -1,0 +1,25 @@
+package com.project.poorlex.exception.payment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class PaymentCustomException extends RuntimeException{
+
+    private final int statusCode;
+    private final PaymentErrorCode errorCode;
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    public PaymentCustomException(PaymentErrorCode errorCode){
+        super(errorCode.getDescription());
+        this.statusCode = HttpStatus.BAD_REQUEST.value();
+        this.errorCode = errorCode;
+    }
+
+    public PaymentCustomException(HttpStatus status, PaymentErrorCode errorCode){
+        super(errorCode.getDescription());
+        this.statusCode = status.value();
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/project/poorlex/exception/payment/PaymentErrorCode.java
+++ b/src/main/java/com/project/poorlex/exception/payment/PaymentErrorCode.java
@@ -1,0 +1,14 @@
+package com.project.poorlex.exception.payment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode {
+
+    FAIL_UPLOAD_IMAGE("이미지 업로드에 실패하였습니다.");
+
+    private final String description;
+
+}

--- a/src/test/java/com/project/poorlex/api/controller/PaymentControllerTest.java
+++ b/src/test/java/com/project/poorlex/api/controller/PaymentControllerTest.java
@@ -1,0 +1,71 @@
+package com.project.poorlex.api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.poorlex.api.service.PaymentService;
+import com.project.poorlex.config.TestSecurityConfig;
+import com.project.poorlex.dto.payment.PaymentCreateRequest;
+import com.project.poorlex.jwt.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
+@WebMvcTest(controllers = {PaymentController.class})
+class PaymentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private PaymentService paymentService;
+
+    @DisplayName("지출 내역 등록 시 지출 내역 목록에 담긴다.")
+    @Test
+    void createPayment() throws Exception {
+        // given
+        PaymentCreateRequest request = PaymentCreateRequest.builder()
+                .amount(200000)
+                .paymentDate(LocalDate.of(2023, 9, 3))
+                .memo("테스트 메모")
+                .build();
+
+        MockMultipartFile requestPart =
+                new MockMultipartFile("request", "", "application/json", objectMapper.writeValueAsBytes(request));
+
+        // when
+        // then
+        mockMvc.perform(
+                        multipart("/payment")
+                                .file(requestPart)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+}

--- a/src/test/java/com/project/poorlex/api/service/PaymentServiceTest.java
+++ b/src/test/java/com/project/poorlex/api/service/PaymentServiceTest.java
@@ -1,12 +1,51 @@
 package com.project.poorlex.api.service;
 
+import com.project.poorlex.IntegrationTestSupport;
+import com.project.poorlex.domain.payment.Payment;
+import com.project.poorlex.domain.payment.PaymentRepository;
+import com.project.poorlex.dto.payment.PaymentCreateRequest;
 import jakarta.transaction.Transactional;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.multipart.MultipartFile;
 
-@ActiveProfiles("test")
-@SpringBootTest
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
 @Transactional
-public class PaymentServiceTest {
+public class PaymentServiceTest extends IntegrationTestSupport {
 
+    @Autowired
+    PaymentService paymentService;
+
+    @Autowired
+    PaymentRepository paymentRepository;
+
+    @Test
+    @DisplayName("지출 내역 등록 시 지출 내역 목록에 담긴다.")
+    void createPayment(){
+        // given
+        PaymentCreateRequest request = PaymentCreateRequest.builder()
+                .amount(200000)
+                .paymentDate(LocalDate.now())
+                .memo("테스트 메모")
+                .build();
+
+        List<MultipartFile> emptyImageList = Collections.emptyList();
+
+        // when
+        paymentService.createPayment(request, emptyImageList);
+        Payment savedPayment = paymentRepository.findTopByOrderByIdDesc();
+
+        // then
+        assertThat(savedPayment).isNotNull();
+        assertThat(request.getAmount()).isEqualTo(savedPayment.getAmount());
+        assertThat(request.getPaymentDate()).isEqualTo(savedPayment.getCreatedDate().toLocalDate());
+        assertThat(request.getMemo()).isEqualTo(savedPayment.getMemo());
+    }
 }

--- a/src/test/java/com/project/poorlex/api/service/PaymentServiceTest.java
+++ b/src/test/java/com/project/poorlex/api/service/PaymentServiceTest.java
@@ -1,0 +1,12 @@
+package com.project.poorlex.api.service;
+
+import jakarta.transaction.Transactional;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+public class PaymentServiceTest {
+
+}


### PR DESCRIPTION
## Issue

- #28 

## Description
- PaymentPhoto -> PaymentImage로 수정하였습니다.
- Controller 호출 테스트, Service 테스트, S3 저장소에 이미지 들어가는 것까지 확인하였습니다.
- 원본파일명이 중복되면 저장소에 덮어쓰기가 되던데 저장 방법 후에 수정하겠습니다.

## Todo
지출 조회, 수정, 삭제

## ETC
- 배틀 방 등록할 때도 이미지를 등록하던데 PaymentImage, BattleImage  이렇게 Image Repository를 두개 만드는게 더 나을까요?
