### PR TITLE
[#29] Feature : 지출 조회 API

### DIFF
--- a/src/main/java/com/project/poorlex/api/controller/PaymentController.java
+++ b/src/main/java/com/project/poorlex/api/controller/PaymentController.java
@@ -3,13 +3,11 @@ package com.project.poorlex.api.controller;
 import com.project.poorlex.api.service.PaymentService;
 import com.project.poorlex.dto.payment.PaymentCreateRequest;
 import com.project.poorlex.dto.payment.PaymentCreateResponse;
+import com.project.poorlex.dto.payment.PaymentSearchResponse;
 import com.project.poorlex.exception.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -20,6 +18,17 @@ import java.util.List;
 public class PaymentController {
 
     private final PaymentService paymentService;
+
+    @GetMapping
+    public ApiResponse<PaymentSearchResponse> searchPaymentAll(){
+        return ApiResponse.ok(paymentService.searchAllPaymentForUser());
+    }
+
+    @GetMapping("/{paymentId}")
+    public ApiResponse<PaymentSearchResponse> searchPaymentByPaymentId(@PathVariable Long paymentId){
+        return ApiResponse.ok(paymentService.searchPaymentByPaymentId(paymentId));
+    }
+
 
     @PostMapping
     public ApiResponse<PaymentCreateResponse> createPayment(

--- a/src/main/java/com/project/poorlex/api/service/PaymentService.java
+++ b/src/main/java/com/project/poorlex/api/service/PaymentService.java
@@ -81,17 +81,17 @@ public class PaymentService {
 
         List<Payment> paymentList = paymentRepository.findPaymentsByMemberId(member.getId());
 
-        return PaymentSearchResponse.from(paymentList);
+        List<PaymentImage> paymentImages = paymentImageRepository.findAllByPaymentIn(paymentList);
+
+        return PaymentSearchResponse.from(paymentList, paymentImages);
     }
 
     public PaymentSearchResponse searchPaymentByPaymentId(Long paymentId) {
-
-        List<Payment> all = paymentRepository.findAll();
-
         Payment payment = paymentRepository.findById(paymentId)
                 .orElseThrow(() -> new PaymentCustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
-        return PaymentSearchResponse.from(payment);
+        List<PaymentImage> paymentImages = paymentImageRepository.findAllByPaymentId(payment.getId());
 
+        return PaymentSearchResponse.from(payment, paymentImages);
     }
 }

--- a/src/main/java/com/project/poorlex/api/service/PaymentService.java
+++ b/src/main/java/com/project/poorlex/api/service/PaymentService.java
@@ -7,6 +7,7 @@ import com.project.poorlex.domain.paymentimage.PaymentImage;
 import com.project.poorlex.domain.paymentimage.PaymentImageRepository;
 import com.project.poorlex.dto.payment.PaymentCreateRequest;
 import com.project.poorlex.dto.payment.PaymentCreateResponse;
+import com.project.poorlex.dto.payment.PaymentSearchResponse;
 import com.project.poorlex.exception.payment.PaymentCustomException;
 import com.project.poorlex.exception.payment.PaymentErrorCode;
 import jakarta.transaction.Transactional;
@@ -19,12 +20,15 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
 
     private final AuthService authService;
+
+    private final S3Service s3Service;
 
     private final PaymentRepository paymentRepository;
 
@@ -50,9 +54,9 @@ public class PaymentService {
         if(images != null && !images.isEmpty()){
             images.forEach(file -> {
                 String key = "payments/" + file.getOriginalFilename(); // S3 내의 저장 경로
-                uploadToS3(file, "poorlex", key);
+                s3Service.uploadToS3(file, "poorlex", key);
 
-                String imageUrl = generateS3Url("poorlex", key);
+                String imageUrl = s3Service.generateS3Url("poorlex", key);
                 savePaymentImages(savedPayment, imageUrl);
             });
         }
@@ -71,22 +75,23 @@ public class PaymentService {
         paymentImageRepository.save(paymentImage);
     }
 
-    private String generateS3Url(String bucketName, String key) {
-        return "https://" + bucketName + ".s3." + Region.AP_NORTHEAST_2.id() + ".amazonaws.com/" + key;
+    public PaymentSearchResponse searchAllPaymentForUser() {
+
+        Member member = authService.findMemberFromToken();
+
+        List<Payment> paymentList = paymentRepository.findPaymentsByMemberId(member.getId());
+
+        return PaymentSearchResponse.from(paymentList);
     }
 
+    public PaymentSearchResponse searchPaymentByPaymentId(Long paymentId) {
 
-    private void uploadToS3(MultipartFile file, String bucketName, String key) {
-        try {
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key(key)
-                    .build();
+        List<Payment> all = paymentRepository.findAll();
 
-            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
-        } catch (Exception e) {
-            throw new PaymentCustomException(PaymentErrorCode.FAIL_UPLOAD_IMAGE);
-        }
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new PaymentCustomException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        return PaymentSearchResponse.from(payment);
+
     }
-
 }

--- a/src/main/java/com/project/poorlex/domain/payment/Payment.java
+++ b/src/main/java/com/project/poorlex/domain/payment/Payment.java
@@ -25,7 +25,7 @@ public class Payment extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.EAGER)
 	private Member member;
 
 	private String memo;

--- a/src/main/java/com/project/poorlex/domain/payment/PaymentRepository.java
+++ b/src/main/java/com/project/poorlex/domain/payment/PaymentRepository.java
@@ -1,9 +1,18 @@
 package com.project.poorlex.domain.payment;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Payment findTopByOrderByIdDesc();
+
+    @Query("SELECT p FROM Payment p WHERE p.member.id = :memberId")
+    List<Payment> findPaymentsByMemberId(@Param("memberId")Long memberId);
+
+    Payment findTopByOrderByIdAsc();
 
 }

--- a/src/main/java/com/project/poorlex/domain/paymentimage/PaymentImageRepository.java
+++ b/src/main/java/com/project/poorlex/domain/paymentimage/PaymentImageRepository.java
@@ -1,6 +1,14 @@
 package com.project.poorlex.domain.paymentimage;
 
+import com.project.poorlex.domain.payment.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PaymentImageRepository extends JpaRepository<PaymentImage, Long> {
+
+    List<PaymentImage> findAllByPaymentIn(List<Payment> payments);
+
+    List<PaymentImage> findAllByPaymentId(Long paymentId);
+
 }

--- a/src/main/java/com/project/poorlex/dto/payment/PaymentDetail.java
+++ b/src/main/java/com/project/poorlex/dto/payment/PaymentDetail.java
@@ -1,0 +1,15 @@
+package com.project.poorlex.dto.payment;
+
+import com.project.poorlex.domain.payment.Payment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PaymentDetail {
+
+    private Payment payment;
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/project/poorlex/dto/payment/PaymentSearchResponse.java
+++ b/src/main/java/com/project/poorlex/dto/payment/PaymentSearchResponse.java
@@ -1,0 +1,29 @@
+package com.project.poorlex.dto.payment;
+
+import com.project.poorlex.domain.payment.Payment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PaymentSearchResponse {
+
+    private final List<Payment> paymentList;
+
+    private final Payment payment;
+
+    public static PaymentSearchResponse from(List<Payment> paymentList) {
+        return PaymentSearchResponse.builder()
+                .paymentList(paymentList)
+                .build();
+    }
+
+    public static PaymentSearchResponse from(Payment payment){
+        return PaymentSearchResponse.builder()
+                .payment(payment)
+                .build();
+    }
+
+}

--- a/src/main/java/com/project/poorlex/dto/payment/PaymentSearchResponse.java
+++ b/src/main/java/com/project/poorlex/dto/payment/PaymentSearchResponse.java
@@ -1,28 +1,49 @@
 package com.project.poorlex.dto.payment;
 
 import com.project.poorlex.domain.payment.Payment;
+import com.project.poorlex.domain.paymentimage.PaymentImage;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
 public class PaymentSearchResponse {
 
-    private final List<Payment> paymentList;
+    private final List<PaymentDetail> paymentDetails;
 
-    private final Payment payment;
+    private final PaymentDetail paymentDetail;
 
-    public static PaymentSearchResponse from(List<Payment> paymentList) {
+    public static PaymentSearchResponse from(List<Payment> paymentList, List<PaymentImage> paymentImages) {
+
+        Map<Long, List<String>> paymentImagesMap = paymentImages.stream()
+                .collect(Collectors.groupingBy(img -> img.getPayment().getId(),
+                        Collectors.mapping(PaymentImage::getUrl, Collectors.toList())));
+
+        List<PaymentDetail> paymentDetails = paymentList.stream()
+                .map(payment -> new PaymentDetail(payment, paymentImagesMap.getOrDefault(payment.getId(), Collections.emptyList())))
+                .collect(Collectors.toList());
+
         return PaymentSearchResponse.builder()
-                .paymentList(paymentList)
+                .paymentDetails(paymentDetails)
                 .build();
     }
 
-    public static PaymentSearchResponse from(Payment payment){
+    public static PaymentSearchResponse from(Payment payment, List<PaymentImage> paymentImages) {
+
+        List<String> imageUrls = paymentImages.stream()
+                                        .map(PaymentImage::getUrl)
+                                        .collect(Collectors.toList());
+
+        PaymentDetail paymentDetail = new PaymentDetail(payment, imageUrls);
+
         return PaymentSearchResponse.builder()
-                .payment(payment)
+                .paymentDetail(paymentDetail)
                 .build();
     }
 

--- a/src/main/java/com/project/poorlex/exception/payment/PaymentErrorCode.java
+++ b/src/main/java/com/project/poorlex/exception/payment/PaymentErrorCode.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PaymentErrorCode {
 
-    FAIL_UPLOAD_IMAGE("이미지 업로드에 실패하였습니다.");
+    FAIL_UPLOAD_IMAGE("이미지 업로드에 실패하였습니다."),
+    PAYMENT_NOT_FOUND("지출 내역을 찾을 수 없습니다.");
 
     private final String description;
 

--- a/src/test/java/com/project/poorlex/api/service/PaymentServiceTest.java
+++ b/src/test/java/com/project/poorlex/api/service/PaymentServiceTest.java
@@ -1,12 +1,18 @@
 package com.project.poorlex.api.service;
 
 import com.project.poorlex.IntegrationTestSupport;
+import com.project.poorlex.domain.member.Member;
+import com.project.poorlex.domain.member.MemberRepository;
 import com.project.poorlex.domain.payment.Payment;
 import com.project.poorlex.domain.payment.PaymentRepository;
 import com.project.poorlex.dto.payment.PaymentCreateRequest;
+import com.project.poorlex.dto.payment.PaymentSearchResponse;
+import com.project.poorlex.exception.payment.PaymentCustomException;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 @Transactional
@@ -25,6 +32,14 @@ public class PaymentServiceTest extends IntegrationTestSupport {
 
     @Autowired
     PaymentRepository paymentRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @BeforeEach
+    void clearRepository(){
+        paymentRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("지출 내역 등록 시 지출 내역 목록에 담긴다.")
@@ -47,5 +62,94 @@ public class PaymentServiceTest extends IntegrationTestSupport {
         assertThat(request.getAmount()).isEqualTo(savedPayment.getAmount());
         assertThat(request.getPaymentDate()).isEqualTo(savedPayment.getCreatedDate().toLocalDate());
         assertThat(request.getMemo()).isEqualTo(savedPayment.getMemo());
+    }
+
+    @Test
+    @DisplayName("지출 아이디 없이 내역 조회 시 해당 사용자의 지출 내역 전체가 조회된다.")
+    void searchPaymentAll(){
+
+        // given
+        Member member = Member.builder()
+                .name("테스트 유저")
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+        BDDMockito.given(authService.findMemberFromToken()).willReturn(member);
+
+        for(int i = 1 ; i <= 10 ; i++){
+            Payment payment = Payment.builder()
+                    .amount(2000 * i)
+                    .member(savedMember)
+                    .memo("지출등록"+i)
+                    .build();
+
+            paymentRepository.save(payment);
+        }
+
+        // when
+        PaymentSearchResponse paymentSearchResponse = paymentService.searchAllPaymentForUser();
+        List<Payment> paymentList = paymentSearchResponse.getPaymentList();
+
+        // then
+        assertThat(paymentList).hasSize(10);
+    }
+
+    @Test
+    @DisplayName("지출 아이디 포함 내역 조회 시 해당 지출 내역이 조회된다.")
+    void searchPaymentByPaymentId(){
+        // given
+        Member member = Member.builder()
+                .name("테스트 유저")
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+        BDDMockito.given(authService.findMemberFromToken()).willReturn(member);
+
+        for(int i = 1 ; i <= 10 ; i++){
+            Payment payment = Payment.builder()
+                    .amount(2000 * i)
+                    .member(savedMember)
+                    .memo("지출등록"+i)
+                    .build();
+
+            paymentRepository.save(payment);
+        }
+        
+        // when
+        PaymentSearchResponse firstPaymentSearchResponse = paymentService.searchPaymentByPaymentId(paymentRepository.findTopByOrderByIdAsc().getId());
+        PaymentSearchResponse lastPaymentSearchResponse = paymentService.searchPaymentByPaymentId(paymentRepository.findTopByOrderByIdDesc().getId());
+
+        assertThat(firstPaymentSearchResponse.getPayment().getAmount()).isEqualTo(2000);
+        assertThat(lastPaymentSearchResponse.getPayment().getAmount()).isEqualTo(2000 * 10);
+        assertThat(firstPaymentSearchResponse.getPayment().getMemo()).isEqualTo("지출등록1");
+        assertThat(lastPaymentSearchResponse.getPayment().getMemo()).isEqualTo("지출등록10");
+    }
+
+    @Test
+    @DisplayName("존재하지 않은 지출 아이디 조회 시 Exception이 발생한다.")
+    void searchPaymentByWrongPaymentId(){
+        // given
+        Member member = Member.builder()
+                .name("테스트 유저")
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+        BDDMockito.given(authService.findMemberFromToken()).willReturn(member);
+
+        for(int i = 1 ; i <= 10 ; i++){
+            Payment payment = Payment.builder()
+                    .amount(2000 * i)
+                    .member(savedMember)
+                    .memo("지출등록"+i)
+                    .build();
+
+            paymentRepository.save(payment);
+        }
+
+        // when
+        // then
+        assertThatThrownBy(() -> paymentService.searchPaymentByPaymentId(-1L))
+                .isInstanceOf(PaymentCustomException.class)
+                .hasMessage("지출 내역을 찾을 수 없습니다.");
     }
 }

--- a/src/test/java/com/project/poorlex/api/service/PaymentServiceTest.java
+++ b/src/test/java/com/project/poorlex/api/service/PaymentServiceTest.java
@@ -6,6 +6,7 @@ import com.project.poorlex.domain.member.MemberRepository;
 import com.project.poorlex.domain.payment.Payment;
 import com.project.poorlex.domain.payment.PaymentRepository;
 import com.project.poorlex.dto.payment.PaymentCreateRequest;
+import com.project.poorlex.dto.payment.PaymentDetail;
 import com.project.poorlex.dto.payment.PaymentSearchResponse;
 import com.project.poorlex.exception.payment.PaymentCustomException;
 import jakarta.transaction.Transactional;
@@ -88,7 +89,7 @@ public class PaymentServiceTest extends IntegrationTestSupport {
 
         // when
         PaymentSearchResponse paymentSearchResponse = paymentService.searchAllPaymentForUser();
-        List<Payment> paymentList = paymentSearchResponse.getPaymentList();
+        List<PaymentDetail> paymentList = paymentSearchResponse.getPaymentDetails();
 
         // then
         assertThat(paymentList).hasSize(10);
@@ -119,10 +120,10 @@ public class PaymentServiceTest extends IntegrationTestSupport {
         PaymentSearchResponse firstPaymentSearchResponse = paymentService.searchPaymentByPaymentId(paymentRepository.findTopByOrderByIdAsc().getId());
         PaymentSearchResponse lastPaymentSearchResponse = paymentService.searchPaymentByPaymentId(paymentRepository.findTopByOrderByIdDesc().getId());
 
-        assertThat(firstPaymentSearchResponse.getPayment().getAmount()).isEqualTo(2000);
-        assertThat(lastPaymentSearchResponse.getPayment().getAmount()).isEqualTo(2000 * 10);
-        assertThat(firstPaymentSearchResponse.getPayment().getMemo()).isEqualTo("지출등록1");
-        assertThat(lastPaymentSearchResponse.getPayment().getMemo()).isEqualTo("지출등록10");
+        assertThat(firstPaymentSearchResponse.getPaymentDetail().getPayment().getAmount()).isEqualTo(2000);
+        assertThat(lastPaymentSearchResponse.getPaymentDetail().getPayment().getAmount()).isEqualTo(2000 * 10);
+        assertThat(firstPaymentSearchResponse.getPaymentDetail().getPayment().getMemo()).isEqualTo("지출등록1");
+        assertThat(lastPaymentSearchResponse.getPaymentDetail().getPayment().getMemo()).isEqualTo("지출등록10");
     }
 
     @Test


### PR DESCRIPTION
## Issue

- #29

## Description
- 해당 사용자의 지출 다건 조회와 단건 조회 기능 구현입니다

## Todo
- 지출 수정
- 지출 삭제

## ETC
- 다건 조회의 경우 문제가 없는데 단건 조회를 실행 시 

[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: org.springframework.http.converter.HttpMessageConversionException: Type definition error: [simple type, class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor]] with root cause

com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: com.project.poorlex.exception.ApiResponse["data"]->com.project.poorlex.dto.payment.PaymentSearchResponse["paymentDetail"]->com.project.poorlex.dto.payment.PaymentDetail["payment"]->com.project.poorlex.domain.payment.Payment["member"]->com.project.poorlex.domain.member.Member$HibernateProxy$N3kRMYdl["hibernateLazyInitializer"])

이런 에러가 발생합니다... 

Payment Entity에서 가지고 있는 Member의 FetchType을 LAZY -> EAGER로 변경 시 에러가 사라지는데 

경험해보신분 계실까요..