### PR TITLE
[#22] Feature : 목표 생성, 수정, 완료, 삭제, 목록 조회 및 완료 목록 조회 API

### DIFF
--- a/src/main/java/com/project/poorlex/api/controller/GoalController.java
+++ b/src/main/java/com/project/poorlex/api/controller/GoalController.java
@@ -15,14 +15,14 @@ public class GoalController {
 
     private final GoalService goalService;
 
-    @PostMapping("/create")
+    @PostMapping
     public ApiResponse<GoalCreateResponse> createGoal(
             @RequestBody GoalCreateRequest request) {
 
         return ApiResponse.ok(goalService.createGoal(request));
     }
 
-    @GetMapping("/list")
+    @GetMapping
     public ApiResponse<List<GoalListResponse>> getAllGoals(@RequestParam String oauthId) {
 
         return ApiResponse.ok(goalService.getAllGoals(oauthId));
@@ -34,7 +34,7 @@ public class GoalController {
         return ApiResponse.ok(goalService.getAllCompletedGoals(oauthId));
     }
 
-    @PutMapping("/update/{id}")
+    @PutMapping("/{id}")
     public ApiResponse<GoalUpdateResponse> updateGoal(
              @PathVariable Long id,
             @RequestBody GoalUpdateRequest request) {
@@ -48,7 +48,7 @@ public class GoalController {
         return ApiResponse.ok(goalService.goalCompleted(id, request));
     }
 
-    @DeleteMapping("/delete/{id}")
+    @DeleteMapping("/{id}")
     public ApiResponse<?> deleteGoal(@PathVariable Long id) {
 
         return ApiResponse.ok(goalService.deleteGoal(id));

--- a/src/main/java/com/project/poorlex/api/controller/GoalController.java
+++ b/src/main/java/com/project/poorlex/api/controller/GoalController.java
@@ -1,0 +1,56 @@
+package com.project.poorlex.api.controller;
+
+import com.project.poorlex.api.service.GoalService;
+import com.project.poorlex.dto.goal.*;
+import com.project.poorlex.exception.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/goal")
+@RequiredArgsConstructor
+public class GoalController {
+
+    private final GoalService goalService;
+
+    @PostMapping("/create")
+    public ApiResponse<GoalCreateResponse> createGoal(
+            @RequestBody GoalCreateRequest request) {
+
+        return ApiResponse.ok(goalService.createGoal(request));
+    }
+
+    @GetMapping("/list")
+    public ApiResponse<List<GoalListResponse>> getAllGoals(@RequestParam String oauthId) {
+
+        return ApiResponse.ok(goalService.getAllGoals(oauthId));
+    }
+
+    @GetMapping("/completedList")
+    public ApiResponse<List<GoalListResponse>> getAllCompletedGoals(@RequestParam String oauthId) {
+
+        return ApiResponse.ok(goalService.getAllCompletedGoals(oauthId));
+    }
+
+    @PutMapping("/update/{id}")
+    public ApiResponse<GoalUpdateResponse> updateGoal(
+             @PathVariable Long id,
+            @RequestBody GoalUpdateRequest request) {
+
+        return ApiResponse.ok(goalService.updateGoal(request, id));
+    }
+
+    @PutMapping("/complete/{id}")
+    public ApiResponse<GoalUpdateResponse> completeGoal(@PathVariable Long id, @RequestBody GoalUpdateRequest request) {
+
+        return ApiResponse.ok(goalService.goalCompleted(id, request));
+    }
+
+    @DeleteMapping("/delete/{id}")
+    public ApiResponse<?> deleteGoal(@PathVariable Long id) {
+
+        return ApiResponse.ok(goalService.deleteGoal(id));
+    }
+}

--- a/src/main/java/com/project/poorlex/api/service/GoalService.java
+++ b/src/main/java/com/project/poorlex/api/service/GoalService.java
@@ -1,0 +1,111 @@
+package com.project.poorlex.api.service;
+
+import com.project.poorlex.domain.goal.Goal;
+import com.project.poorlex.domain.goal.GoalRepository;
+import com.project.poorlex.domain.member.Member;
+import com.project.poorlex.domain.member.MemberRepository;
+import com.project.poorlex.dto.goal.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GoalService {
+
+    private final GoalRepository goalRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final AuthService authService;
+
+    public GoalCreateResponse createGoal(GoalCreateRequest request) {
+
+//        Optional<Member> optionalMember = memberRepository.findByOauthId(request.getOauthId());
+//        if (!optionalMember.isPresent()) {
+//            throw new RuntimeException("id not found.");
+//        }
+//
+//        Member member = optionalMember.get();
+        Member member = authService.findMemberFromToken();
+
+        Goal goal = Goal.builder()
+                .member(member)
+                .name(request.getName())
+                .amount(request.getAmount())
+                .currentAmount(request.getCurrentAmount())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .isCompleted(request.isCompleted())
+                .build();
+
+        goalRepository.save(goal);
+
+        return GoalCreateResponse.of(goal);
+    }
+
+    public List<GoalListResponse> getAllGoals(String oauthId) {
+
+
+        List<Goal> goalList = goalRepository.findAllByMemberId_OauthIdAndIsCompletedFalse(oauthId);
+
+        return GoalListResponse.of(goalList);
+    }
+
+    public List<GoalListResponse> getAllCompletedGoals(String oauthId) {
+
+        List<Goal> goalList = goalRepository.findAllByMemberId_OauthIdAndIsCompletedTrue(oauthId);
+
+        return GoalListResponse.of(goalList);
+    }
+
+    public GoalUpdateResponse updateGoal(GoalUpdateRequest request, Long id) {
+
+//        Member member = memberRepository.findByOauthId(oauthId).orElseThrow(() -> new RuntimeException("Id not found"));
+        Member  member = authService.findMemberFromToken();
+        Long goalId = goalRepository.findById(id).orElseThrow(() -> new RuntimeException("Goal not found"))
+                .getId();
+
+        Goal updatedGoal = Goal.builder()
+                .id(goalId)
+                .member(member)
+                .amount(request.getAmount())
+                .currentAmount(request.getCurrentAmount())
+                .name(request.getName())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .isCompleted(false)
+                .build();
+
+        goalRepository.save(updatedGoal);
+
+        return GoalUpdateResponse.of(updatedGoal);
+    }
+
+    public GoalUpdateResponse goalCompleted(Long id, GoalUpdateRequest request) {
+
+        Long goalId = goalRepository.findById(id).orElseThrow(() -> new RuntimeException("Goal not found"))
+                .getId();
+        Goal completedGoal = Goal.builder()
+                .id(goalId)
+                .amount(request.getAmount())
+                .currentAmount(request.getCurrentAmount())
+                .name(request.getName())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .isCompleted(true)
+                .build();
+
+        goalRepository.save(completedGoal);
+
+        return GoalUpdateResponse.of(completedGoal);
+    }
+
+    public boolean deleteGoal(Long id) {
+
+        goalRepository.deleteById(id);
+
+        return true;
+    }
+}

--- a/src/main/java/com/project/poorlex/api/service/GoalService.java
+++ b/src/main/java/com/project/poorlex/api/service/GoalService.java
@@ -85,7 +85,8 @@ public class GoalService {
 
     public GoalUpdateResponse goalCompleted(Long id, GoalUpdateRequest request) {
 
-        Long goalId = goalRepository.findById(id).orElseThrow(() -> new RuntimeException("Goal not found"))
+        Long goalId = goalRepository.findById(id)
+            .orElseThrow(() -> new GoalCustomException(GoalErrorCode.GOAL_NOT_FOUND))
                 .getId();
         Goal completedGoal = Goal.builder()
                 .id(goalId)

--- a/src/main/java/com/project/poorlex/domain/goal/Goal.java
+++ b/src/main/java/com/project/poorlex/domain/goal/Goal.java
@@ -43,8 +43,9 @@ public class Goal extends BaseEntity {
 	private boolean isCompleted;
 
 	@Builder
-	private Goal(Member member, String name, String photoUrl, int amount, int currentAmount,
+	private Goal(Long id, Member member, String name, String photoUrl, int amount, int currentAmount,
 		LocalDateTime startDate, LocalDateTime endDate, boolean isCompleted) {
+		this.id = id;
 		this.member = member;
 		this.name = name;
 		this.photoUrl = photoUrl;

--- a/src/main/java/com/project/poorlex/domain/goal/GoalRepository.java
+++ b/src/main/java/com/project/poorlex/domain/goal/GoalRepository.java
@@ -2,5 +2,10 @@ package com.project.poorlex.domain.goal;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface GoalRepository extends JpaRepository<Goal, Long> {
+    List<Goal> findAllByMemberId_OauthIdAndIsCompletedFalse(String oauthId);
+
+    List<Goal> findAllByMemberId_OauthIdAndIsCompletedTrue(String oauthId);
 }

--- a/src/main/java/com/project/poorlex/dto/goal/GoalCreateRequest.java
+++ b/src/main/java/com/project/poorlex/dto/goal/GoalCreateRequest.java
@@ -1,0 +1,26 @@
+package com.project.poorlex.dto.goal;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class GoalCreateRequest {
+
+    private String oauthId;
+    private String name;
+    private int amount;
+    private int currentAmount;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startDate;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endDate;
+    private boolean isCompleted;
+
+}

--- a/src/main/java/com/project/poorlex/dto/goal/GoalCreateResponse.java
+++ b/src/main/java/com/project/poorlex/dto/goal/GoalCreateResponse.java
@@ -1,0 +1,26 @@
+package com.project.poorlex.dto.goal;
+
+import com.project.poorlex.domain.goal.Goal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class GoalCreateResponse {
+
+    Long id;
+
+    String message;
+
+    public static GoalCreateResponse of(Goal goal) {
+
+        return GoalCreateResponse.builder()
+                .id(goal.getId())
+                .message("목표가 생성되었습니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/project/poorlex/dto/goal/GoalListResponse.java
+++ b/src/main/java/com/project/poorlex/dto/goal/GoalListResponse.java
@@ -1,0 +1,58 @@
+package com.project.poorlex.dto.goal;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.project.poorlex.domain.goal.Goal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class GoalListResponse {
+
+    private Long id;
+
+    String name;
+
+    String message;
+
+    private int amount;
+
+    private int currentAmount;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endDate;
+
+    private boolean isCompleted;
+
+    public static List<GoalListResponse> of(List<Goal> goals) {
+
+        List<GoalListResponse> goalListResponseList = new ArrayList<>();
+
+        if (goals != null) {
+            for (Goal goal : goals) {
+                goalListResponseList.add(GoalListResponse.builder()
+                        .id(goal.getId())
+                        .name(goal.getName())
+                        .amount(goal.getAmount())
+                        .currentAmount(goal.getCurrentAmount())
+                        .startDate(goal.getStartDate())
+                        .endDate(goal.getEndDate())
+                        .isCompleted(goal.isCompleted())
+                        .message("리스트가 조회되었습니다.")
+                        .build());
+            }
+        }
+        return goalListResponseList;
+    }
+}

--- a/src/main/java/com/project/poorlex/dto/goal/GoalUpdateRequest.java
+++ b/src/main/java/com/project/poorlex/dto/goal/GoalUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.project.poorlex.dto.goal;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class GoalUpdateRequest {
+
+    private String oauthId;
+
+    private Long id;
+
+    private String name;
+
+    private int amount;
+
+    private int currentAmount;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endDate;
+}

--- a/src/main/java/com/project/poorlex/dto/goal/GoalUpdateResponse.java
+++ b/src/main/java/com/project/poorlex/dto/goal/GoalUpdateResponse.java
@@ -1,0 +1,25 @@
+package com.project.poorlex.dto.goal;
+
+import com.project.poorlex.domain.goal.Goal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Builder
+public class GoalUpdateResponse {
+
+    Long id;
+    String message;
+
+    public static GoalUpdateResponse of(Goal goal) {
+
+        return GoalUpdateResponse.builder()
+                .id(goal.getId())
+                .message("목표가 수정되었습니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/project/poorlex/exception/goal/GoalCustomException.java
+++ b/src/main/java/com/project/poorlex/exception/goal/GoalCustomException.java
@@ -1,0 +1,16 @@
+package com.project.poorlex.exception.goal;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class GoalCustomException extends RuntimeException {
+
+    private final GoalErrorCode goalErrorCode;
+    public GoalCustomException(GoalErrorCode goalErrorCode) {
+        super(goalErrorCode.getDescription());
+        this.goalErrorCode = goalErrorCode;
+    }
+}

--- a/src/main/java/com/project/poorlex/exception/goal/GoalErrorCode.java
+++ b/src/main/java/com/project/poorlex/exception/goal/GoalErrorCode.java
@@ -1,0 +1,13 @@
+package com.project.poorlex.exception.goal;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GoalErrorCode {
+
+    GOAL_NOT_FOUND("목표명이 존재하지 않습니다.");
+
+    private final String description;
+}

--- a/src/test/java/com/project/poorlex/domain/goal/GoalServiceTest.java
+++ b/src/test/java/com/project/poorlex/domain/goal/GoalServiceTest.java
@@ -1,0 +1,77 @@
+package com.project.poorlex.domain.goal;
+import com.project.poorlex.api.service.AuthService;
+import com.project.poorlex.api.service.GoalService;
+import com.project.poorlex.domain.member.MemberRepository;
+import com.project.poorlex.dto.goal.GoalListResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@SpringBootTest(classes = GoalService.class)
+public class GoalServiceTest {
+
+    @Autowired
+    private GoalService goalService;
+
+    @MockBean
+    private GoalRepository goalRepository;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    @DisplayName("Test getAllGoals")
+    public void testGetAllGoals() {
+
+        List<Goal> goalList = new ArrayList<>(Arrays.asList(
+                Goal.builder()
+                        .id(2L)
+                        .amount(500000)
+                        .name("목표는 에어맥스")
+                        .currentAmount(2000)
+                        .startDate(LocalDateTime.of(2023, 9, 3, 9, 0))
+                        .endDate(LocalDateTime.of(2023, 12, 31, 18, 0))
+                        .isCompleted(false)
+                        .build()
+        ));
+
+        when(goalRepository.findAllByMemberId_OauthIdAndIsCompletedFalse(anyString())).thenReturn(goalList);
+
+
+        String oauthId = "oauthId";
+
+        List<GoalListResponse> result = goalService.getAllGoals(oauthId);
+
+        List<GoalListResponse> goalListResponse = GoalListResponse.of(goalList);
+
+        assertGoalsListEquals(goalListResponse, result);
+    }
+
+    private void assertGoalsListEquals(List<GoalListResponse> expected, List<GoalListResponse> actual) {
+        assertEquals(expected.size(), actual.size(), "크기가 일치하지 않습니다.");
+
+        for (int i = 0; i < expected.size(); i++) {
+            GoalListResponse expectedItem = expected.get(i);
+            GoalListResponse actualItem = actual.get(i);
+
+            assertEquals(expectedItem.getId(), actualItem.getId(), "ID가 일치하지 않습니다. " + i);
+            assertEquals(expectedItem.getName(), actualItem.getName(), "이름이 일치하지 않습니다. " + i);
+            assertEquals(expectedItem.isCompleted(), actualItem.isCompleted(), "완료 상태가 일치하지 않습니다. " + i);
+        }
+    }
+}


### PR DESCRIPTION
## Issue

- https://github.com/Poorlex/BE_poorlex/issues/22

## Description

- 사용자 목표 생성, 수정, 완료, 조회 기능 입니다.

## Todo

- 달력 생성

## ETC

- Goal entity의 builder에 id 추가하는 걸로 수정 했는데 괜찮을까요..?
